### PR TITLE
Include a file for the human state output when executing equivalence tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,9 @@ Each test case executes the following Terraform commands in order:
 1. `terraform init`
 2. `terraform plan -out=equivalence_test_plan`
 3. `terraform apply -json equivalence_test_plan`
-4. `terraform show -json`
-5. `terraform show -json equivalence_test_plan`
+4. `terraform show`
+5. `terraform show -json`
+6. `terraform show -json equivalence_test_plan`
 
 Consult the [Test Specification Format](#test-specification-format) section for
 a run down on how to customise these commands using the `Commands` 
@@ -249,6 +250,13 @@ the custom `commands` entry in the test specification.
       "output_file_name": "apply.json",
       "has_json_output": true,
       "streams_json_output": true
+    },
+    {
+      "name": "state",
+      "arguments": ["show", "-no-color"],
+      "capture_output": true,
+      "output_file_name": "state",
+      "has_json_output": false
     },
     {
       "name": "show_state",

--- a/examples/example_golden_files/complex_resource/state
+++ b/examples/example_golden_files/complex_resource/state
@@ -1,0 +1,25 @@
+# data.tfcoremock_simple_resource.simple_resource:
+data "tfcoremock_simple_resource" "simple_resource" {
+    id      = "192977d6-b169-4170-a9d4-ee1dcef7c6ea"
+    integer = 2
+}
+
+# tfcoremock_complex_resource.complex_resource:
+resource "tfcoremock_complex_resource" "complex_resource" {
+    id      = "d199d8ea-e8f8-4fb0-8276-3567a74d3db8"
+    integer = 2
+    list    = [
+        # (2 unchanged elements hidden)
+    ]
+    object  = {
+        bool   = true
+        string = "hello"
+    }
+
+    list_block {
+        string = "two.one"
+    }
+    list_block {
+        string = "two.two"
+    }
+}

--- a/examples/example_golden_files/simple_resource/state
+++ b/examples/example_golden_files/simple_resource/state
@@ -1,0 +1,5 @@
+# tfcoremock_simple_resource.simple_resource:
+resource "tfcoremock_simple_resource" "simple_resource" {
+    id      = "192977d6-b169-4170-a9d4-ee1dcef7c6ea"
+    integer = 1
+}

--- a/internal/terraform/terraform.go
+++ b/internal/terraform/terraform.go
@@ -138,10 +138,13 @@ func (t *terraform) ExecuteTest(directory string, includeFiles []string, command
 		if savedFiles["apply.json"], err = t.apply(); err != nil {
 			return nil, err
 		}
-		if savedFiles["state.json"], err = t.showState(); err != nil {
+		if savedFiles["state"], err = t.showState(); err != nil {
 			return nil, err
 		}
-		if savedFiles["plan.json"], err = t.showPlan(); err != nil {
+		if savedFiles["state.json"], err = t.showJsonState(); err != nil {
+			return nil, err
+		}
+		if savedFiles["plan.json"], err = t.showJsonPlan(); err != nil {
 			return nil, err
 		}
 	} else {
@@ -226,8 +229,16 @@ func (t *terraform) apply() (*files.File, error) {
 	return files.NewJsonFile(json), nil
 }
 
-func (t *terraform) showPlan() (*files.File, error) {
-	capture, err := run(exec.Command(t.binary, "show", "-json", "equivalence_test_plan"), "show plan")
+func (t *terraform) showState() (*files.File, error) {
+	capture, err := run(exec.Command(t.binary, "show", "-no-color"), "show state")
+	if err != nil {
+		return nil, err
+	}
+	return files.NewRawFile(capture.ToString()), nil
+}
+
+func (t *terraform) showJsonPlan() (*files.File, error) {
+	capture, err := run(exec.Command(t.binary, "show", "-json", "equivalence_test_plan"), "show json plan")
 	if err != nil {
 		return nil, err
 	}
@@ -239,8 +250,8 @@ func (t *terraform) showPlan() (*files.File, error) {
 	return files.NewJsonFile(json), nil
 }
 
-func (t *terraform) showState() (*files.File, error) {
-	capture, err := run(exec.Command(t.binary, "show", "-json"), "show state")
+func (t *terraform) showJsonState() (*files.File, error) {
+	capture, err := run(exec.Command(t.binary, "show", "-json"), "show json state")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The path by which the state is rendered for human consumption follows a different generation and setup than the plan rendering, so I think the equivalence tests can also monitor it for changes.

We do monitor the JSON output for both the state and the plan so it makes sense to me we should do the same for the human output.