### PR TITLE
Update default filters to remove more timestamps

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
       - run: go mod download
       - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
         with:
-          terraform_version: 1.4.6
+          terraform_version: 1.10.0
           terraform_wrapper: false
       - name: Check examples
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@
 .idea
 
 dist/
+
+bin/

--- a/examples/example_golden_files/complex_resource/apply.json
+++ b/examples/example_golden_files/complex_resource/apply.json
@@ -37,11 +37,9 @@
   },
   {
     "@level": "info",
-    "@message": "tfcoremock_complex_resource.complex_resource: Creation complete after 0s [id=d199d8ea-e8f8-4fb0-8276-3567a74d3db8]",
     "@module": "terraform.ui",
     "hook": {
       "action": "create",
-      "elapsed_seconds": 0,
       "id_key": "id",
       "id_value": "d199d8ea-e8f8-4fb0-8276-3567a74d3db8",
       "resource": {
@@ -63,6 +61,7 @@
     "changes": {
       "add": 1,
       "change": 0,
+      "import": 0,
       "operation": "apply",
       "remove": 0
     },

--- a/examples/example_golden_files/complex_resource/plan.json
+++ b/examples/example_golden_files/complex_resource/plan.json
@@ -1,4 +1,6 @@
 {
+  "applyable": true,
+  "complete": true,
   "configuration": {
     "provider_config": {
       "tfcoremock": {
@@ -71,7 +73,8 @@
       ]
     }
   },
-  "format_version": "1.1",
+  "errored": false,
+  "format_version": "1.2",
   "planned_values": {
     "root_module": {
       "resources": [

--- a/examples/example_golden_files/simple_resource/apply.json
+++ b/examples/example_golden_files/simple_resource/apply.json
@@ -37,11 +37,9 @@
   },
   {
     "@level": "info",
-    "@message": "tfcoremock_simple_resource.simple_resource: Creation complete after 0s [id=192977d6-b169-4170-a9d4-ee1dcef7c6ea]",
     "@module": "terraform.ui",
     "hook": {
       "action": "create",
-      "elapsed_seconds": 0,
       "id_key": "id",
       "id_value": "192977d6-b169-4170-a9d4-ee1dcef7c6ea",
       "resource": {
@@ -63,6 +61,7 @@
     "changes": {
       "add": 1,
       "change": 0,
+      "import": 0,
       "operation": "apply",
       "remove": 0
     },

--- a/examples/example_golden_files/simple_resource/plan.json
+++ b/examples/example_golden_files/simple_resource/plan.json
@@ -1,4 +1,6 @@
 {
+  "applyable": true,
+  "complete": true,
   "configuration": {
     "provider_config": {
       "tfcoremock": {
@@ -27,7 +29,8 @@
       ]
     }
   },
-  "format_version": "1.1",
+  "errored": false,
+  "format_version": "1.2",
   "planned_values": {
     "root_module": {
       "resources": [

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/terraform-equivalence-testing
 
-go 1.18
+go 1.23
 
 require (
 	github.com/google/go-cmp v0.5.9

--- a/internal/json/step.go
+++ b/internal/json/step.go
@@ -1,0 +1,52 @@
+package json
+
+import "strconv"
+
+// Step represents a step in the path to a field that should be stripped from
+// the input data.
+type Step struct {
+	Step   string
+	Filter []Filter
+}
+
+// Filter represents a filter that should be validated before a Field is
+// stripped.
+type Filter struct {
+	Path  []string
+	Value interface{}
+}
+
+func (step Step) applyFilter(data interface{}) bool {
+	for _, f := range step.Filter {
+		if !filter(f.Path, f.Value, data) {
+			return false
+		}
+	}
+	return true
+}
+
+func filter(parts []string, target interface{}, data interface{}) bool {
+	if data == nil {
+		return false
+	}
+
+	if len(parts) == 0 {
+		return target == data
+	}
+
+	switch data := data.(type) {
+	case map[string]interface{}:
+		return filter(parts[1:], target, data[parts[0]])
+	case []interface{}:
+		ix, err := strconv.Atoi(parts[0])
+		if err != nil {
+			return false
+		}
+		if ix < 0 || ix >= len(data) {
+			return false
+		}
+		return filter(parts[1:], target, data[ix])
+	default:
+		return false
+	}
+}

--- a/internal/json/strip_test.go
+++ b/internal/json/strip_test.go
@@ -440,6 +440,49 @@ func TestStripJson(t *testing.T) {
 				},
 			},
 		},
+		{
+			input: []interface{}{
+				map[string]interface{}{
+					"value": "one",
+					"tags": map[string]interface{}{
+						"env": "prod",
+					},
+				},
+				map[string]interface{}{
+					"value": "two",
+					"tags": map[string]interface{}{
+						"env": "dev",
+					},
+				},
+				map[string]interface{}{
+					"value": "three",
+					"tags": map[string]interface{}{
+						"env": "prod",
+					},
+				},
+			},
+			expected: []interface{}{
+				map[string]interface{}{
+					"value": "two",
+					"tags": map[string]interface{}{
+						"env": "dev",
+					},
+				},
+			},
+			fields: [][]Step{
+				{
+					{
+						Step: wildcard,
+						Filter: []Filter{
+							{
+								Path:  []string{"tags", "env"},
+								Value: "prod",
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 	for ix, tc := range tcs {
 		t.Run(fmt.Sprintf("%d", ix), func(t *testing.T) {

--- a/internal/json/strip_test.go
+++ b/internal/json/strip_test.go
@@ -13,12 +13,12 @@ func TestStripJson(t *testing.T) {
 	tcs := []struct {
 		input    interface{}
 		expected interface{}
-		fields   []string
+		fields   [][]Step
 	}{
 		{
 			input:    map[string]interface{}{},
 			expected: map[string]interface{}{},
-			fields:   []string{},
+			fields:   [][]Step{},
 		},
 		{
 			input: map[string]interface{}{
@@ -53,7 +53,7 @@ func TestStripJson(t *testing.T) {
 					},
 				},
 			},
-			fields: []string{},
+			fields: [][]Step{},
 		},
 		{
 			input: map[string]interface{}{
@@ -78,8 +78,8 @@ func TestStripJson(t *testing.T) {
 					"two": "two",
 				},
 			},
-			fields: []string{
-				"list",
+			fields: [][]Step{
+				Field("list"),
 			},
 		},
 		{
@@ -106,8 +106,8 @@ func TestStripJson(t *testing.T) {
 				},
 				"list": []interface{}{},
 			},
-			fields: []string{
-				"list.*",
+			fields: [][]Step{
+				Field("list.*"),
 			},
 		},
 		{
@@ -131,8 +131,8 @@ func TestStripJson(t *testing.T) {
 					},
 				},
 			},
-			fields: []string{
-				"map.one",
+			fields: [][]Step{
+				Field("map.one"),
 			},
 		},
 		{
@@ -151,8 +151,8 @@ func TestStripJson(t *testing.T) {
 			expected: map[string]interface{}{
 				"map": map[string]interface{}{},
 			},
-			fields: []string{
-				"map.*",
+			fields: [][]Step{
+				Field("map.*"),
 			},
 		},
 		{
@@ -177,8 +177,8 @@ func TestStripJson(t *testing.T) {
 					},
 				},
 			},
-			fields: []string{
-				"map.one.*",
+			fields: [][]Step{
+				Field("map.one.*"),
 			},
 		},
 		{
@@ -211,9 +211,9 @@ func TestStripJson(t *testing.T) {
 					},
 				},
 			},
-			fields: []string{
-				"map.one",
-				"list.*.one",
+			fields: [][]Step{
+				Field("map.one"),
+				Field("list.*.one"),
 			},
 		},
 		{
@@ -245,8 +245,8 @@ func TestStripJson(t *testing.T) {
 					},
 				},
 			},
-			fields: []string{
-				"map",
+			fields: [][]Step{
+				Field("map"),
 			},
 		},
 		{
@@ -280,9 +280,9 @@ func TestStripJson(t *testing.T) {
 					},
 				},
 			},
-			fields: []string{
-				"list.0.one",
-				"list.1.two",
+			fields: [][]Step{
+				Field("list.0.one"),
+				Field("list.1.two"),
 			},
 		},
 		{
@@ -298,8 +298,146 @@ func TestStripJson(t *testing.T) {
 					"two": "two",
 				},
 			},
-			fields: []string{
-				"other_map.one",
+			fields: [][]Step{
+				Field("other_map.one"),
+			},
+		},
+		{
+			input: []interface{}{
+				map[string]interface{}{
+					"value":  "one",
+					"filter": "true",
+				},
+				map[string]interface{}{
+					"value":  "two",
+					"filter": "false",
+				},
+				map[string]interface{}{
+					"value":  "three",
+					"filter": "true",
+				},
+				map[string]interface{}{
+					"value":  "four",
+					"filter": "false",
+				},
+			},
+			expected: []interface{}{
+				map[string]interface{}{
+					"value":  "two",
+					"filter": "false",
+				},
+				map[string]interface{}{
+					"value":  "four",
+					"filter": "false",
+				},
+			},
+			fields: [][]Step{
+				{
+					{
+						Step: wildcard,
+						Filter: []Filter{
+							{
+								Path:  []string{"filter"},
+								Value: "true",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			input: []interface{}{
+				map[string]interface{}{
+					"value":  "one",
+					"filter": "true",
+				},
+				map[string]interface{}{
+					"value":  "two",
+					"filter": "false",
+				},
+				map[string]interface{}{
+					"value":  "three",
+					"filter": "true",
+				},
+				map[string]interface{}{
+					"value":  "four",
+					"filter": "false",
+				},
+			},
+			expected: []interface{}{
+				map[string]interface{}{
+					"filter": "true",
+				},
+				map[string]interface{}{
+					"value":  "two",
+					"filter": "false",
+				},
+				map[string]interface{}{
+					"filter": "true",
+				},
+				map[string]interface{}{
+					"value":  "four",
+					"filter": "false",
+				},
+			},
+			fields: [][]Step{
+				{
+					{
+						Step: wildcard,
+						Filter: []Filter{
+							{
+								Path:  []string{"filter"},
+								Value: "true",
+							},
+						},
+					},
+					{
+						Step: "value",
+					},
+				},
+			},
+		},
+		{
+			input: []interface{}{
+				map[string]interface{}{
+					"value": "one",
+				},
+				map[string]interface{}{
+					"value": "two",
+				},
+				map[string]interface{}{
+					"value": "three",
+				},
+				map[string]interface{}{
+					"value": "four",
+				},
+			},
+			expected: []interface{}{
+				map[string]interface{}{},
+				map[string]interface{}{
+					"value": "two",
+				},
+				map[string]interface{}{
+					"value": "three",
+				},
+				map[string]interface{}{
+					"value": "four",
+				},
+			},
+			fields: [][]Step{
+				{
+					{
+						Step: wildcard,
+					},
+					{
+						Step: "value",
+						Filter: []Filter{
+							{
+								Value: "one",
+							},
+						},
+					},
+				},
 			},
 		},
 	}


### PR DESCRIPTION
This removes any `elapsed_seconds` fields, and removes the `@message` field from `apply_complete` message in the apply JSON output.

This should help with the flaky tests such as https://github.com/hashicorp/terraform/pull/36172. Anything with timestamps is subject to the whims of the computer, and can't really be included.