### PR TITLE
Add .vscode folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,6 @@
 # vendor/
 
 .idea
+.vscode
 
 dist/


### PR DESCRIPTION
I've been using VS Code's debugger to learn about this codebase, which means making files in a .vscode folder. By gitignoring this folder I can save and forget about the debugging config I've made there.

Here's the debug config I've been using. I'd prefer to not commit it to this repo as committing the .vscode/launch.json file would mean that people have to use the config prescribed by the repo.

```json
{
    "version": "0.2.0",
    "configurations": [
        {
            // Allows running the project in debug mode against the example files
            "name": "Run Tool in Debug Mode",
            "type": "go",
            "request": "launch",
            "mode": "debug",
            "program": "${workspaceFolder}",
            "args": [
                "diff", // diff or update
                "--goldens=./examples/example_golden_files",
                "--tests=./examples/example_test_cases",
                "--filters=complex_resource",
            ],
        },
    ],
}
```