### PR TITLE
Make all paths supplied by flags absolute

### DIFF
--- a/internal/cmd/flags.go
+++ b/internal/cmd/flags.go
@@ -66,5 +66,21 @@ func ParseFlags(command string, args []string) (*Flags, error) {
 		flags.TerraformBinaryPath = path.Join(wd, flags.TerraformBinaryPath)
 	}
 
+	if !filepath.IsAbs(flags.GoldenFilesDirectory) {
+		path, err := filepath.Abs(flags.GoldenFilesDirectory)
+		if err != nil {
+			return nil, err
+		}
+		flags.GoldenFilesDirectory = path
+	}
+
+	if !filepath.IsAbs(flags.TestingFilesDirectory) {
+		path, err := filepath.Abs(flags.TestingFilesDirectory)
+		if err != nil {
+			return nil, err
+		}
+		flags.TestingFilesDirectory = path
+	}
+
 	return &flags, nil
 }

--- a/internal/cmd/flags.go
+++ b/internal/cmd/flags.go
@@ -6,8 +6,6 @@ package cmd
 import (
 	"errors"
 	"flag"
-	"os"
-	"path"
 	"path/filepath"
 )
 
@@ -58,14 +56,14 @@ func ParseFlags(command string, args []string) (*Flags, error) {
 	// if the caller has asked to just execute the default Terraform system
 	// command/binary.
 	if !filepath.IsAbs(flags.TerraformBinaryPath) && flags.TerraformBinaryPath != "terraform" {
-		wd, err := os.Getwd()
+		path, err := filepath.Abs(flags.TerraformBinaryPath)
 		if err != nil {
 			return nil, err
 		}
-
-		flags.TerraformBinaryPath = path.Join(wd, flags.TerraformBinaryPath)
+		flags.TerraformBinaryPath = path
 	}
 
+	// Make directory paths absolute, too
 	if !filepath.IsAbs(flags.GoldenFilesDirectory) {
 		path, err := filepath.Abs(flags.GoldenFilesDirectory)
 		if err != nil {


### PR DESCRIPTION
Closes https://github.com/hashicorp/terraform-equivalence-testing/issues/34

This PR makes the `--goldens` and `--tests` flag values be converted to absolute paths before they're used. This avoids the problem described in the linked issue.

I also changed how the path to the Terraform binary is made absolute, so that it's consistent. The function filepath.Abs is [implemented pretty much the same way as the code that's being replaced](https://cs.opensource.google/go/go/+/master:src/path/filepath/path.go;drc=4ce116a884bd55d7046dbc999f329fa417414c00;l=165):


```go
// src/path/filepath/path.go
func Abs(path string) (string, error) {
	return abs(path)
}

// src/path/filepath/path_unix.go
func abs(path string) (string, error) {
	return unixAbs(path)
}

// src/path/filepath/path.go
func unixAbs(path string) (string, error) {
	if IsAbs(path) {
		return Clean(path), nil
	}
	wd, err := os.Getwd()
	if err != nil {
		return "", err
	}
	return Join(wd, path), nil
}
```

---

I'm unsure of any pitfalls around converting paths to absolute paths, which is the main thing I'd like to address during review. E.g. usage on non-unix machines?