### PR TITLE
Upgrade to Go 1.24.3, `go mod tidy`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/hashicorp/terraform-equivalence-testing
 
-go 1.23.0
-
-toolchain go1.24.1
+go 1.24.1
 
 require (
 	github.com/google/go-cmp v0.5.9

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/terraform-equivalence-testing
 
-go 1.24.1
+go 1.24.3
 
 require (
 	github.com/google/go-cmp v0.5.9


### PR DESCRIPTION
I saw some minor caching issues in the GHAs that I think might be due to using two versions of Go, so this PR reduces it one version across the board